### PR TITLE
Correct spelling

### DIFF
--- a/data/munros.json
+++ b/data/munros.json
@@ -896,7 +896,7 @@
   },
 
   {
-    "name": "Stob Coire Sgreamach",
+    "name": "Stob Coire Sgreamhach",
     "height": 1072,
     "gridref_letters": "NN",
     "gridref_eastings": "15487",


### PR DESCRIPTION
Hi John, 

There appears to be a typo on one the munros. 

Here is the source. 
https://www.walkhighlands.co.uk/munros/stob-coire-sgreamhach

Great API thanks for maintaining this resource. 